### PR TITLE
CI: release rockspec for Lua upon release

### DIFF
--- a/.github/workflows/publish-luarocks.yaml
+++ b/.github/workflows/publish-luarocks.yaml
@@ -1,0 +1,74 @@
+name: Publish LuaRocks package
+on:
+  release:
+    types:
+      - published
+permissions:
+  contents: read
+concurrency:
+  group: luarocks-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+jobs:
+  publish:
+    name: Publish to LuaRocks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Setup lua toolchain
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: "5.4.8"
+      - name: Install LuaRocks
+        uses: leafo/gh-actions-luarocks@v6
+        with:
+          luarocksVersion: "3.13.0"
+      - name: Resolve and validate rockspec
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          case "$RELEASE_TAG" in
+            v*)
+              package_version="${RELEASE_TAG#v}"
+              ;;
+            *)
+              echo "::error::Release tag must start with 'v', for example v0.12.4"
+              exit 1
+              ;;
+          esac
+
+          mapfile -t rockspecs < <(
+            compgen -G "lua/kcl_lib-${package_version}-*.rockspec" || true
+          )
+
+          if [[ "${#rockspecs[@]}" -ne 1 ]]; then
+            echo "::error::Expected exactly one rockspec matching lua/kcl_lib-${package_version}-*.rockspec"
+            printf 'Found: %s\n' "${rockspecs[@]:-none}"
+            exit 1
+          fi
+
+          rockspec="${rockspecs[0]}"
+
+          expected_version_line="local package_version = \"${package_version}\""
+          if ! grep -Fqx "$expected_version_line" "$rockspec"; then
+            echo "::error::The package_version in $rockspec does not match release tag $RELEASE_TAG"
+            exit 1
+          fi
+
+          echo "Publishing $rockspec"
+          echo "ROCKSPEC=$rockspec" >> "$GITHUB_ENV"
+      - name: Lint rockspec
+        run: luarocks lint "$ROCKSPEC"
+      - name: Publish rockspec and source rock
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        run: |
+          set -euo pipefail
+          luarocks upload \
+            --temp-key "$LUAROCKS_API_KEY" \
+            "$ROCKSPEC"

--- a/lua/README.md
+++ b/lua/README.md
@@ -8,13 +8,20 @@ enables you to work with KCL modules, configurations, and artifacts directly fro
 
 ## Installation
 
-### From Source
-
-#### Prerequisites
+You will need the following tooling regardless of which installation approach you choose. The rock
+is currently packaged as sources files rather than architecture dependent binaries.
 
 - **Rust** (with Cargo) - For building the library.
 - **Lua** - The target Lua version you want to use.
 - **LuaRocks** - The Lua package manager to manage the build and installation.
+
+### From LuaRocks
+
+```bash
+luarocks install kcl_lib
+```
+
+### From Source
 
 #### Supported Lua Versions
 

--- a/lua/kcl_lib-0.12.4-1.rockspec
+++ b/lua/kcl_lib-0.12.4-1.rockspec
@@ -5,20 +5,23 @@ rockspec_format = "3.0"
 package = "kcl_lib"
 version = package_version .. "-" .. rockspec_revision
 source = {
-  url = "git+https://github.com/kcl-lang/lib",
-  -- tag = "lua/v" .. version,
+  url = "git+https://github.com/kcl-lang/lib.git",
+  tag = "v" .. package_version,
+  dir = "lib/lua",
 }
 description = {
   summary = "KCL Lua Bindings",
   detailed = [[
-      KCL Lua Bindings
+      KCL Lua bindings to interact with KCL files directly in Lua.
     ]],
   homepage = "https://kcl-lang.io/",
-  license = " Apache-2.0",
+  license = "Apache-2.0",
+}
+build_dependencies = {
+  "luarocks-build-rust-mlua = 0.2.0",
 }
 dependencies = {
-  "lua >= 5.1",
-  "luarocks-build-rust-mlua = 0.2.0",
+  "lua >= 5.1, < 5.5",
   "lua-protobuf >= 0.5",
   "dkjson >= 2.9",
 }


### PR DESCRIPTION
The following must be done for the LuaRocks publishing to work **before** publishing a new release on GH:

1. Rename the rockspec file to `kcl_lib-<version>-1.rockspec`.
2. Update `package_version` in the rockspec.

Right now the following would need to be done to ensure this can be published:

1. Create an account on https://luarocks.org/ (ideally called `kcl-lang` to represent the GH org).
2. Create an API key for that account.
3. Store the API key in this repository's secrets under the name `LUAROCKS_API_KEY`.

@Peefy I can create the account and generate the API key if you want and then send them to you somehow. However it probably makes more sense that you do this as I don't have permissions to update secrets in this repository and it makes sense that you control the kcl-lang account on LuaRocks IMO.