### PR TITLE
fix(lua): allow to install rocks under not system default version

### DIFF
--- a/lua/kcl_lib-0.12.4-1.rockspec
+++ b/lua/kcl_lib-0.12.4-1.rockspec
@@ -18,9 +18,10 @@ description = {
   license = "Apache-2.0",
 }
 build_dependencies = {
-  "luarocks-build-rust-mlua = 0.2.0",
+  -- "luarocks-build-rust-mlua = 0.2.0", see: https://github.com/luarocks/luarocks/issues/1880
 }
 dependencies = {
+  "luarocks-build-rust-mlua = 0.2.0", -- see: comment in `build_dependencies`
   "lua >= 5.1, < 5.5",
   "lua-protobuf >= 0.5",
   "dkjson >= 2.9",


### PR DESCRIPTION
See: luarocks/luarocks#1880

This is due to a current (slightly wierd) behaviour of LuaRocks where `--lua-version` is not respected for build dependencies. The change in this PR is needed if a user wants to install the library for a different Lua version than the system default one. This is commonly the case for this, as it does not support Lua 5.5, which is for instance the default on Arch Linux and others.
